### PR TITLE
docs(flask): `async-in-sync` example should use the portal

### DIFF
--- a/advanced_alchemy/extensions/flask/extension.py
+++ b/advanced_alchemy/extensions/flask/extension.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from advanced_alchemy.exceptions import ImproperConfigurationError
 from advanced_alchemy.extensions.flask.cli import database_group
 from advanced_alchemy.extensions.flask.config import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
-from advanced_alchemy.utils.portals import PortalProvider
+from advanced_alchemy.utils.portals import Portal, PortalProvider
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -43,6 +43,11 @@ class AdvancedAlchemy:
 
         if app is not None:
             self.init_app(app)
+
+    @property
+    def portal(self) -> "Portal":
+        """Get the portal."""
+        return self.portal_provider.portal
 
     @property
     def config(self) -> "Sequence[Union[SQLAlchemyAsyncConfig, SQLAlchemySyncConfig]]":

--- a/docs/usage/frameworks/flask.rst
+++ b/docs/usage/frameworks/flask.rst
@@ -86,6 +86,7 @@ Advanced Alchemy supports async SQLAlchemy with Flask:
 
 You can also safely use an AsyncSession in your routes within a sync context.
 
+
 .. warning::
 
     This is experimental and may change in the future.
@@ -94,8 +95,8 @@ You can also safely use an AsyncSession in your routes within a sync context.
 
     @app.route("/users")
     def list_users():
-        session = alchemy.get_sync_session()
-        users = session.execute(select(User))
+        session = alchemy.get_async_session()
+        users = alchemy.portal.call(session.execute, select(User))
         return {"users": [user.dict() for user in users.scalars()]}
 
 Configuration


### PR DESCRIPTION
Update the Flask example that uses the `portal` class.

Fixes #361
 