### PR TITLE
fix: handle relationship data in `model_from_dict` for service.create()

### DIFF
--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -97,9 +97,9 @@ def model_from_dict(model: type[ModelT], **kwargs: Any) -> ModelT:
         ModelT: A new instance of the model populated with the provided values.
     """
     data = {
-        column_name: kwargs[column_name]
-        for column_name in model.__mapper__.columns.keys()  # noqa: SIM118  # pyright: ignore[reportUnknownMemberType]
-        if column_name in kwargs
+        attr_name: kwargs[attr_name]
+        for attr_name in model.__mapper__.attrs.keys()  # noqa: SIM118  # pyright: ignore[reportUnknownMemberType]
+        if attr_name in kwargs
     }
     return model(**data)
 


### PR DESCRIPTION
Fixed regression where service.create() method stopped handling relationship data correctly when passed SQLAlchemy model instances. Changed model_from_dict() in _util.py to use __mapper__.attrs.keys() instead of __mapper__.columns.keys() to include relationship attributes alongside column attributes.
 - Use attrs.keys() to include both columns and relationships
 - Add comprehensive tests for relationship handling in model_from_dict
 - Verify unknown attributes are still ignored

Co-Authored-By: rseeley <rseeley@users.noreply.github.com>